### PR TITLE
feat: allow installing script with git

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,3 @@
+{
+  "root_directory": "Release"
+}


### PR DESCRIPTION
GitHub [will remove SVN support in 2024](https://github.blog/2023-01-20-sunsetting-subversion-support/). Allow this script to be installed using git. 